### PR TITLE
Changes to tight-binding tutorials TB_06 to TB_09

### DIFF
--- a/TB_06/run.ipynb
+++ b/TB_06/run.ipynb
@@ -17,7 +17,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "TBtrans is capable of calculating transport in $N\\ge 1$ electrode systems. In this example, we will explore a 4-terminal graphene GNR crossbar (one zGNR, the other aGNR) system."
+    "TBtrans is capable of calculating transport in $N\\ge 1$ electrode systems. In this example, we will explore a 4-terminal graphene nano-ribbon (GNR) crossbar (one zig-zag GNR, the other armchair GNR) system."
    ]
   },
   {
@@ -140,7 +140,7 @@
     "---\n",
     "\n",
     "Ensure the lattice vectors are big enough for plotting.\n",
-    "Try and convince your-self that the lattice vectors are unimportant for TBtrans in this example.  \n",
+    "Try and convince yourself that the lattice vectors are unimportant for TBtrans in this example.  \n",
     "*HINT*: what is the periodicity?"
    ]
   },
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since this system has 4 electrodes, we need to tell TBtrans where the 4 electrodes are in the device. The following lines prints out the fdf-lines that are appropriate for each of the electrodes (`RUN.fdf` is already filled correctly):"
+    "Since this system has four electrodes, we need to tell TBtrans where the 4 electrodes are in the device. The following lines prints out the fdf-lines that are appropriate for each of the electrodes (`RUN.fdf` is already filled correctly):"
    ]
   },
   {
@@ -191,7 +191,7 @@
    "source": [
     "# Exercises\n",
     "\n",
-    "In this example, we have more than 1 transmission path. Before you run the below code which plots all relevant transmissions ($T_{ij}$ for $j>i$), consider if there are any symmetries, and if so, determine how many different transmission spectra you should expect? Please plot the geometry using your favourite geometry viewer (`molden`, `Jmol`, ...). The answer is not so trivial."
+    "In this example, we have more than one transmission path. Before you run the below code which plots all relevant transmissions ($T_{ij}$ for $j>i$), consider if there are any symmetries, and if so, determine how many different transmission spectra you should expect? Please plot the geometry using your favourite geometry viewer (`molden`, `Jmol`, `gdis`, ...). The answer is not so trivial."
    ]
   },
   {
@@ -240,7 +240,7 @@
    "metadata": {},
    "source": [
     "- In `RUN.fdf` we have added the flag `TBT.T.All` which tells TBtrans to calculate *all* transmissions, i.e. between all $i\\to j$ for all $i,j \\in \\{1,2,3,4\\}$. This flag is by default `False`, why?\n",
-    "- Create 3 plots each with $T_{1j}$ and $T_{j1}$ for all $j\\neq1$."
+    "- Create three plots each with $T_{1j}$ and $T_{j1}$ for all $j\\neq1$."
    ]
   },
   {
@@ -275,8 +275,8 @@
    "metadata": {},
    "source": [
     "- Considering symmetries, try to figure out which transmissions ($T_{ij}$) are unique?\n",
-    "- Plot the bulk DOS for the 2 differing electrodes.\n",
-    "- Plot the spectral DOS injected by all 4 electrodes."
+    "- Plot the bulk DOS for the two differing electrodes.\n",
+    "- Plot the spectral DOS injected by all four electrodes."
    ]
   },
   {
@@ -294,7 +294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Bulk density of states:"
+    "Bulk density-of-states:"
    ]
   },
   {
@@ -312,9 +312,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Spectral density of states for all electrodes:\n",
-    "- As a final exercise, you can explore the details of the density of states for single atoms. Take for instance atom 205 (204 in Python index) which is in *both* GNRs at the crossing.  \n",
-    "Feel free to play around with different atoms, subset of atoms (pass a `list`) etc.  "
+    "Spectral density-of-states for all electrodes:\n",
+    "- As a final exercise, you can explore the details of the density-of-states for single atoms. Take for instance atom 205 (204 in Python index) which is in *both* GNRs at the crossing.  \n",
+    "Feel free to play around with different atoms, subset of atoms (pass a `list`), etc.  "
    ]
   },
   {
@@ -325,14 +325,14 @@
    "source": [
     "Eplot(..., label=r'$ADOS_1$');\n",
     "...\n",
-    "plt.ylabel('DOS [1/eV/N]'); plt.xlabel('Energy [eV]'); plt.ylim([0, None]); plt.legend();"
+    "plt.ylabel('DOS/N [1/eV]'); plt.xlabel('Energy [eV]'); plt.ylim([0, None]); plt.legend();"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- For 2D structures one can easily plot the DOS per atom via a scatter plot in `matplotlib`, here is the skeleton code for that, you should select an energy point and figure out how to extract the atom resolved DOS (you will need to look up the documentation for the `ADOS` method to figure out which flag to use)."
+    "- For 2D structures one can easily plot the DOS per atom via a scatter plot in `matplotlib`. Here is the skeleton code for that. You should select an energy point and figure out how to extract the atom resolved DOS (you will need to look up the documentation for the `ADOS` method to figure out which flag to use)."
    ]
   },
   {

--- a/TB_07/run.ipynb
+++ b/TB_07/run.ipynb
@@ -22,7 +22,7 @@
     "One of the key ideas behind `sisl` was the interaction of a DFT Hamiltonian and the user.  \n",
     "In this example, we will highlight a unique implementation in TBtrans which enables ***any*** kind of user intervention.\n",
     "\n",
-    "The idea is a transformation of the Green function calculation from:\n",
+    "The idea is a transformation of the Green's function calculation from:\n",
     "\\begin{equation}\n",
     "   \\mathbf G^{-1}(E) = \\mathbf S (E + i\\eta) - \\mathbf H - \\sum_i\\boldsymbol\\Sigma_i\n",
     "\\end{equation}\n",
@@ -30,10 +30,10 @@
     "\\begin{equation}\n",
     "   \\mathbf G^{-1}(E) = \\mathbf S (E + i\\eta) - \\mathbf H - \\delta\\mathbf H - \\sum_i\\boldsymbol\\Sigma_i - \\delta\\boldsymbol \\Sigma\n",
     "\\end{equation}\n",
-    "where $\\delta\\mathbf H$ and $\\delta\\boldsymbol\\Sigma$ can be of any type, i.e. complex and/or real.  \n",
+    "Where $\\mathbf G$ is the Green's function of the system, $\\mathbf S$ is the corresponding overlap matrix, *E* is the energy, $\\mathbf H$ is the Hamiltonian matrix and $\\boldsymbol\\Sigma$ the self-energy/ies. The $\\delta\\mathbf H$ and $\\delta\\boldsymbol\\Sigma$ terms are the perturbation to the Hamiltonian and self-energy/ies, respectively, and can be of any type, i.e. complex and/or real.  \n",
     "The only (important!) difference between $\\delta\\mathbf H$ and $\\delta\\boldsymbol \\Sigma$ is that the former enters the calculation of bond-transmissions, while the latter does not.\n",
     "\n",
-    "Since TBtrans by it-self does not allow complex Hamiltonians, the above is a way to remove this restriction. One feature this may be used for is by applying magnetic fields.\n",
+    "Since TBtrans by itself does not allow complex Hamiltonians, the above is a way to remove this restriction. One feature this may be used for is to simulate the application of magnetic fields.\n",
     "\n",
     "In the following we will use Peierls substitution on a square tight-binding model:\n",
     "\\begin{equation}\n",
@@ -43,7 +43,7 @@
     "\n",
     "---\n",
     "\n",
-    "First, create a square lattice and define the on-site and nearest neighbour couplings"
+    "First, create a square lattice and define the on-site and nearest-neighbour couplings"
    ]
   },
   {
@@ -79,7 +79,7 @@
     "\n",
     "# Make a constriction\n",
     "geom = H.geometry.translate( -H.geometry.center(what='xyz') )\n",
-    "# This constriction is based on an example in the kwant project (called qhe). We however make a slight modification.\n",
+    "# This constriction is based on an example in the Kwant project (called qhe). We however make a slight modification.\n",
     "# Remove some atoms, this will create a constriction of 100 - 40 * 2 = 20 Ang with a Gaussian edge profile\n",
     "remove = (np.abs(geom.xyz[:, 1]) > 50 - 37.5 * np.exp( -(geom.xyz[:, 0] / 12) **2 )).nonzero()[0]\n",
     "# To reduce computations we find the atoms in the constriction such that we can \n",
@@ -87,8 +87,8 @@
     "device = (np.abs(geom.remove(remove).xyz[:, 0]) < .6).nonzero()[0]\n",
     "geom.remove(remove).write('test.xyz')\n",
     "\n",
-    "# Pretty print a range of atoms that is the smallest device region\n",
-    "# note this is fortran indices\n",
+    "# Pretty-print the range of atoms within such smaller device region\n",
+    "# Note this is Fortran indices (as required for TBtrans) \n",
     "print(sisl.utils.list2str(device + 1))\n",
     "\n",
     "H = H.remove(remove)\n",
@@ -100,8 +100,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above printed list of atoms should be inserted in the `RUN.fdf` in the `TBT.Atoms.Device`. This is important when one is *only* interested in the transmission, and does not care about the density of states. You are always encouraged to select the minimal device region to 1) speed up computations and 2) drastically reduce memory requirements.  \n",
-    "In this regard you should read in the TBtrans manual about the additional flag `TBT.Atoms.Device.Connect` (you may try, as an additional exercise, to set this flag to true and check the difference from the previous calculation).\n",
+    "The above printed list of atoms should be specified in the `RUN.fdf` file via the `TBT.Atoms.Device` flag. This is important when one is *only* interested in the transmission, and does not care about the density-of-states. You are always encouraged to select the minimal device region to 1) speed-up computations and 2) drastically reduce memory requirements.  \n",
+    "In this regard you should read-in the TBtrans manual about the additional flag `TBT.Atoms.Device.Connect` (you may try, as an additional exercise, to set this flag to `True` and check the resulting difference with the previous calculation).\n",
     "\n",
     "Now we have $\\mathbf H(0)$ with *no* phases due to magnetic fields. As the magnetic field is changing the Hamiltonian, and thus enters the bond-transmission calculations, we have to use the $\\delta\\mathbf H$ term (and *not* $\\delta\\boldsymbol\\Sigma$).\n",
     "\n",
@@ -165,7 +165,7 @@
     "## Exercises\n",
     "\n",
     "- Calculate all physical quantities for all different applied magnetic fields.  \n",
-    "   Before running the calculations, search the manual on how to save the self-energies (*HINT* out-of-core). By default, TBtrans calculates the self-energies as they are needed. However, if one has the same electrodes, same $k$-grid and same $E$-points for several different runs (as in this case) one can with benefit calculate the self-energies *once*, and then reuse them in subsequent calculations.\n",
+    "   Before running the calculations, search the manual on how to save the self-energies (*HINT*: `out-of-core`). By default, TBtrans calculates the self-energies as they are needed. However, if one has the same electrodes, same $k$-grid and same $E$-points for several different runs (as in this case) one can with benefit calculate the self-energies *once*, and then reuse them in subsequent calculations.\n",
     "\n",
     "   To ease the calculation of all magnetic fields, a script (`run.sh`) is located in this directory which will loop over the different fields. Carefully read it to infer which option specifies the $\\delta \\mathbf H$ term.\n",
     "   \n",
@@ -203,7 +203,7 @@
    "outputs": [],
    "source": [
     "# Do trick with easy plotting utility\n",
-    "E = tbt0.E[:]\n",
+    "E = tbt0.E\n",
     "Eplot = partial(plt.plot, E)\n",
     "\n",
     "for rec_phi, tbt in zip(rec_phis, tbts):\n",
@@ -236,7 +236,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- **TIME** Choose a given magnetic field and create a different set of constriction widths and plot $T(E, \\Phi)$ for different widths, fix $\\Phi$ at a fairly large value (copy codes in `In [4-7]` and adapt), you may decide the Gaussian profile and change if you want."
+    "- **TIME**: Choose a given magnetic field and create a set of constrictions of different width.  Plot $T(E, \\Phi)$ for increasing widths, fixing $\\Phi$ at a fairly large value (copy codes in `In [4-7]` and adapt). You may decide the Gaussian profile and change it if you want."
    ]
   },
   {
@@ -260,11 +260,11 @@
     "## Learned lessons\n",
     "\n",
     "- Advanced construction of geometries by removing subsets of atoms (both for Hamiltonian and geometries)\n",
-    "- Creation of $\\delta\\mathbf H$ terms. Note that *exactly* the same method is used for the $\\delta\\boldsymbol\\Sigma$ terms, the only difference is how it is specified in the fdf-file (`TBT.dH` vs. `TBT.dSE`). Please look in the manual and figure out what the difference is between the two methods?\n",
-    "- Supplying fdf-flags to TBtrans on the command line to override flags in the input files.\n",
+    "- Creation of $\\delta\\mathbf H$ terms. Note that *exactly* the same method is used for the $\\delta\\boldsymbol\\Sigma$ terms, the only difference is how it is specified in the *fdf*-file (`TBT.dH` vs. `TBT.dSE`). Please look in the TBtrans manual and figure out what the difference is between the two flags?\n",
+    "- Supplying *fdf*-flags to TBtrans on the command line to override flags in the input files.\n",
     "- Inform TBtrans to store the self-energies on disk to re-use them in later calculations.\n",
-    "- Inform TBtrans to make all output into a sub-folder (and if it does not exist, create it)\n",
-    "- Adding complex valued Hamiltonians, we have not uncovered everything as the $\\delta$ files may contain $k$-resolved and/or $E$-resolved $\\delta$-terms for full control, but the principles are the same. Search the documentation for `deltancSileTBtrans`."
+    "- Inform TBtrans to save all output into a sub-folder (and if it does not exist, create it)\n",
+    "- Adding complex-valued perturbations to the Hamiltonian matrix. We have not uncovered everything, as the $\\delta$ files may contain $k$-resolved and/or $E$-resolved $\\delta$-terms for full control, but the principles are the same. Search the documentation for `deltancSileTBtrans`."
    ]
   }
  ],

--- a/TB_08/run.ipynb
+++ b/TB_08/run.ipynb
@@ -18,16 +18,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In TBtrans and TranSiesta one is capable of performing real space transport calculations by using real space self-energies (see [here](https://doi.org/10.1103/PhysRevB.100.195417)).  \n",
-    "Currently, the real space self-energy calculation *has* to be performed in `sisl` since it is not implemented in TranSiesta.\n",
+    "In TBtrans and TranSiesta one is capable of performing real-space transport calculations by using real-space self-energies (see [here](https://doi.org/10.1103/PhysRevB.100.195417)).  \n",
+    "Currently, the real-space self-energy calculation *has* to be performed in `sisl` since it is not implemented in TranSiesta.\n",
     "\n",
-    "A real space self-energy is a $\\mathbf k$ averaged self-energy which can emulate *any* 2D or 3D electrode. I.e. for an STM junction a tip and a surface. In such a system, the surface could be modelled using the real space self-energy to remove mirror effects of STM tips. This is important since the distance between periodic images disturbs the calculation due to long range potential effects.\n",
+    "A real-space self-energy is a $\\mathbf k$-averaged self-energy which can emulate *any* 2D or 3D electrode. I.e. for an STM junction a tip and a surface. In such a system, the surface could be modelled using the real-space self-energy to remove mirror effects of the STM tip periodic images. This is important since the distance between periodic images disturbs the calculation due to long range potential effects.\n",
     "\n",
-    "The basic principle for calculating the real space self-energy is the Brillouin zone integral:\n",
+    "The basic principle for calculating the real-space self-energy is the Brillouin zone integral:\n",
     "\\begin{equation}\n",
     "   \\mathbf G_{\\mathcal R}(E) = \\int_{\\mathrm{BZ}}\\mathbf G_\\mathbf k(E) = \\int_{\\mathrm{BZ}} \\big[E \\mathbf S_{\\mathbf k} - \\mathbf H_{\\mathbf k}\\big]^{-1}\n",
     "\\end{equation}\n",
-    "In this example, we will construct an STM tip probing a graphene flake.\n",
+    "Where $\\mathbf G_{\\mathcal R}$ is the real-space Green function, *E* is the energy, and $\\mathbf G_\\mathbf k$, $\\mathbf S_{\\mathbf k}$ and $\\mathbf H_{\\mathbf k}$ are the Green function, overlap matrix and Hamiltonian, respectively, at a given **k**-point. Integration is done over the entire Brillouin-zone ($\\mathrm{BZ}$). \n",
+    "\n",
+    "In this example, we will construct a STM tip probing a graphene flake.\n",
     "\n",
     "\n",
     "---\n",
@@ -62,12 +64,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once the minimal graphene unit-cell (here orthogonal) is created, we now turn to the calculation of the real space self-energy.  \n",
+    "Once the minimal graphene unit-cell (here orthogonal) is created, we now turn to the calculation of the real-space self-energy.  \n",
     "The construction of this object is somewhat complicated and has a set of required input options:\n",
     "- `object`: the Hamiltonian\n",
-    "- `semi_axis`: which axis to use for the recursive self-energy\n",
+    "- `semi_axis`: which axis to use for the recursive calculation of the self-energy\n",
     "- `k_axes`: which axes to integrate in the Brillouin zone\n",
-    "- `unfold`: how many times the `object` needs to be unfolded along each lattice vector, this is an integer vector of length 3"
+    "- `unfold`: how many times the `object` needs to be unfolded along each lattice vector, this is an integer vector of length three"
    ]
   },
   {
@@ -79,7 +81,7 @@
     "# object = H_minimal\n",
     "# semi_axis = 0, x-axis uses recursive self-energy calculation\n",
     "# k_axes = 1, y-axis uses a Brillouin zone integral\n",
-    "# unfold = (10, 10, 1), the full real-space green function is equivalent to the system\n",
+    "# unfold = (10, 10, 1), the full real-space Green function is equivalent to the system\n",
     "#                       H_minimal.tile(10, 0).tile(10, 1)\n",
     "RSSE = sisl.RealSpaceSE(H_minimal, 0, 1, (10, 10, 1))"
    ]
@@ -88,21 +90,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can create the real space, self-energy.  \n",
+    "Now we can create the real-space self-energy.  \n",
     "In TBtrans (and TranSiesta) the electrode atomic indices *must* be in consecutive order.\n",
-    "This is a little troublesome since the natural order in a device would be in order according to $x$, $y$ or $z$. To create the correct order we extract the *real space coupling* matrix which is where the real space self-energy would live, the self-energy is calculated using:\n",
+    "This is a little troublesome since the natural order in a device would be in order according to $x$, $y$ or $z$. To create the correct order we extract the *real-space coupling* matrix which is where the real-space self-energy would live. The self-energy ($\\boldsymbol\\Sigma^{\\mathcal R}$) is calculated using:\n",
     "\\begin{align}\n",
     "   \\mathbf G^{\\mathcal R}(E) &= \\big[E \\mathbf S^{\\mathcal R} - \\mathbf H^{\\mathcal R} - \\boldsymbol\\Sigma^{\\mathcal R}\\big]^{-1}\n",
     "   \\\\\n",
     "   \\boldsymbol\\Sigma^{\\mathcal R}(E) &= E \\mathbf S^{\\mathcal R} - \\mathbf H^{\\mathcal R} - \\Big[\\mathbf G^{\\mathcal R}(E)\\Big]^{-1}.\n",
     "\\end{align}\n",
-    "Another way to calculate the self-energy would be to transfer the Green function from the infinite bulk into the region of interest:\n",
+    "Where $\\mathbf S^{\\mathcal R}$ and $\\mathbf H^{\\mathcal R}$ are the real-space overlap matrix and Hamiltonian, respectively. Another way to calculate the self-energy would be to transfer the Green function from the infinite bulk into the region of interest:\n",
     "\\begin{equation}\n",
     "   \\boldsymbol\\Sigma^{\\mathcal R} = \\mathbf V_{\\infty\\setminus\\mathcal R,\\mathcal R}\\mathbf G_{\\mathcal R,\\infty\\setminus\\mathcal R}\\mathbf V_{\\infty\\setminus\\mathcal R,\\mathcal R}.\n",
     "\\end{equation}\n",
-    "From the 2nd equation it is obvious that the self-energy only lives on the boundary that $\\mathbf V_{\\infty\\mathcal R,\\mathcal R}$ couples to. Exactly this region is extracted using `real_space_coupling` as below. Take some time to draw a simple 2D lattice coupling and confirm the area that the real-space self energies couples to.\n",
-    "\n",
-    "*HINT:* draw the unit-cell for a 4x4 square lattice with nearest neighbour couplings, then mark the atoms that couple to atoms outside the unit-cell.  \n",
+    "Where $\\mathbf V_{\\infty\\setminus\\mathcal R,\\mathcal R}$ is the **to_be_filled** and $\\mathbf G_{\\mathcal R,\\infty\\setminus\\mathcal R}$ is the **to_be_filled**. From the second equation it is obvious that the self-energy only lives on the boundary that $\\mathbf V_{\\infty\\mathcal R,\\mathcal R}$ couples to. Exactly this region is extracted using `real_space_coupling` as below. Take some time to draw a simple 2D lattice coupling and confirm the area that the real-space self-energies couple to.\n",
+    "*HINT:* Draw the unit-cell for a 4x4 square lattice with nearest-neighbour couplings, then mark the atoms that couple to atoms outside the unit-cell.  \n",
     "\n",
     "----\n",
     "\n",
@@ -123,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above yields the electrode region which contains the self-energies. Since the full device region is nothing but the `H_minimal` tiled $10\\times10$ times with an attached STM tip on top. Here we need to arrange the electrode atoms first, and then the final atoms of the device region after. The `real_space_parent` method returns the Hamiltonian that obeys the *unfolded* size. In this case $10\\times10$ times larger. One should always use this method to get the correct device order of atoms, since the order of tiling is determined by the `semi_axes` and `k_axis` arguments."
+    "The above yields the electrode region which contains the self-energies. The full device region is nothing but the `H_minimal` tiled $10\\times10$ times with an attached STM tip on top. Here we need to arrange the electrode atoms first, and then the final atoms of the device region after. The `real_space_parent` method returns the Hamiltonian that obeys the *unfolded* size - in this case $10\\times10$ times larger. One should always use this method to get the correct device order of atoms, since the order of tiling is determined by the `semi_axes` and `k_axis` arguments."
    ]
   },
   {
@@ -146,7 +147,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lastly, we need to add the STM tip. Here we simply add a gold atom and manually add the hoppings. Since this is tight-binding we have full control over the self-energy and potential land-scape. Therefore we don't need to extend the electrode region to screen off the tip region. In DFT systems, a properly screened region is required."
+    "Lastly, we need to add the STM tip. Here we simply add a gold atom and manually add the hoppings. Since this is tight-binding, we have full control over the self-energy and potential landscape. Therefore we don't need to extend the electrode region to screen-off the tip region. In DFT systems a screening region is required."
    ]
   },
   {
@@ -168,7 +169,6 @@
    "outputs": [],
    "source": [
     "mid_xyz = H.geometry.center()\n",
-    "# Get a random \n",
     "idx = H.close(mid_xyz, R=1.33)[0]\n",
     "H_device = H.add(H_STM, offset=H.geometry.xyz[idx] - H_STM.geometry.xyz[0] + [0, 0, 2])\n",
     "idx_STM = len(H_device) - 1\n",
@@ -190,10 +190,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before we can run calculations, we need to create the real space self-energy for the graphene flake in `sisl`.\n",
+    "Before we can run calculations, we need to create the real-space self-energy for the graphene flake in `sisl`.\n",
     "Since the algorithm is not implemented in TBtrans (nor TranSiesta) it needs to be done here.\n",
     "\n",
-    "This is somewhat complicated since the files requires a specific order. For ease, this tutorial implements it for you."
+    "This is somewhat complicated since the files require a specific order. For ease, this tutorial implements it for you."
    ]
   },
   {
@@ -202,9 +202,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# A real space transport calculation ONLY needs the Gamma-point\n",
+    "# A real-space transport calculation ONLY needs the Gamma-point\n",
     "gamma = sisl.MonkhorstPack(H_elec, [1, 1, 1])\n",
-    "# Energy contour\n",
+    "# Energy-contour\n",
     "dE = 0.04\n",
     "E = np.arange(-2, 2 + dE / 2, dE)\n",
     "sisl.io.tableSile(\"contour.E\", 'w').write_data(E, np.zeros(E.size) + dE)"
@@ -233,16 +233,16 @@
    "source": [
     "## Exercises\n",
     "\n",
-    "- Calculate transport, density of state and bond-transmissions.  \n",
+    "- Calculate transport, density-of-states and bond-transmissions.  \n",
     "   Please search the manual on how to edit the `RUN.fdf` according to the following:\n",
-    "   - Force `tbtrans` to use the generated `TBTGF` file. This is the same as in [TB_07](../TB_07/run.ipynb) example, i.e. using `out-of-core` calculations\n",
-    "   - Force `tbtrans` to use an energy grid defined in an external file (`contour.E`), search the `tbtrans` manual.\n",
+    "   - Force `tbtrans` to use the generated `TBTGF` file. This is the same as in [TB_07](../TB_07/run.ipynb) example, i.e. using the `out-of-core` tag\n",
+    "   - Force `tbtrans` to use an energy grid defined in an external file (`contour.E`). Search the `tbtrans` manual.\n",
     "   \n",
     "- Plot the bond-transmissions and check their symmetry, does the symmetry depend on the injection point?\n",
     "- Is there a particular reason for choosing `semi_axis` and `k_axes` as they are chosen? Or could they be swapped?\n",
     "\n",
-    "- **TIME** Redo the calculations using 3 electrodes (left/right/tip) using *k*-points. Converge transmission and then plot the bond-transmissions.  \n",
-    "   Do they look as the real space calculation? If they are the same, why?"
+    "- **TIME**: Redo the calculations using three electrodes (left/right/tip) using *k*-points. Converge transmission and then plot the bond-transmissions.  \n",
+    "   Do they look as the real-space calculation? If they are the same, why?"
    ]
   },
   {
@@ -276,16 +276,16 @@
    "source": [
     "## Learned lessons\n",
     "\n",
-    "- Creation of real space self-energies\n",
+    "- Creation of real-space self-energies\n",
     "- Manual specification of energy points for TBtrans\n",
     "- Manual creation of self-energy files for TBtrans\n",
-    "- Force TBtrans to use an existing **TBTGF** file on disk."
+    "- Forcing TBtrans to use an existing **TBTGF** file on disk, previously created with `sisl`."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },

--- a/TB_09/run.ipynb
+++ b/TB_09/run.ipynb
@@ -24,7 +24,7 @@
     "In this example, you will learn how to find and calculate properties of *bound states* in NEGF calculations. In this example, the bound states are physically decoupled from the electrodes, hence *bound*. However, in more complicated calculations one might still encounter bound states, even if the atoms are neighbours. E.g. it may be that symmetries makes them *bound*.\n",
     "\n",
     "This example is very similar to [TB 5](../TB_05/run.ipynb), with the small change that some atoms are retained in the middle of the hole.\n",
-    "You should again use the self-energies which basically is inverting, multiplying and adding matrices, roughly 10–20 times per $k$-point, per energy point, per electrode.  Please ensure \n",
+    "You should again re-use the self-energies which, when built from scratch, require inverting, multiplying and adding matrices, roughly 10–20 times per $k$-point, per energy point, per electrode. \n",
     "For systems with large electrodes compared to the full device, this becomes more demanding than calculating the Green function for the system.  \n",
     "When there is periodicity in electrodes along the transverse semi-infinite direction (not along the transport direction) one can utilize Bloch's theorem to reduce the computational cost of calculating the self-energy.\n",
     "\n",
@@ -103,7 +103,7 @@
     "\n",
     "Instead of analysing the same thing as in [TB 5](../TB_05/run.ipynb) you should perform the following actions to explore the available data-analysis capabilities of TBtrans. *Remember*: always use Bloch's theorem when applicable!\n",
     "\n",
-    "*HINT* please copy as much as you like from example 04/05 to simplify the following tasks.\n",
+    "*HINT*: please copy as much as you like from example 04/05 to simplify the following tasks.\n",
     "\n",
     "1. Read in the resulting file into a variable called `tbt`.\n",
     "2. In the following, we will concentrate on *only* looking at $\\Gamma$-point related quantities. I.e. all quantities should only be plotted for this $k$-point.  \n",
@@ -113,17 +113,17 @@
     "   \n",
     "   which may be used to find a resulting $k$-point index in the result file.\n",
     "   \n",
-    "3. Plot the transmission ($\\Gamma$-point only). To extract a subset $k$-point you should read the documentation for the functions (*hint: `kavg` is the keyword you are looking for*).\n",
+    "3. Plot the transmission ($\\Gamma$-point only). To extract transmission for a subset $k$-point you should read the documentation of the specific function (*HINT*: `kavg` is the keyword you are looking for).\n",
     "   - Full transmission\n",
-    "   - Bulk transmission\n",
-    "   How does it compare to example 05, should it be different?\n",
+    "   - Bulk transmission. \n",
+    "   How does it compare to example [TB 5](../TB_05/run.ipynb)? Should it be different?\n",
     "4. Plot the DOS with normalization according to the number of atoms ($\\Gamma$ only)  \n",
-    "   Plot on the edge atoms, and compare with example 5\n",
+    "   Plot on the edge atoms, and compare with example [TB 5](../TB_05/run.ipynb)\n",
     "   - The Green function DOS (edge and bound atoms)\n",
-    "   - The spectral DOS (edge and bound atoms), what is special for this value on the bound atoms?\n",
-    "   - The bulk DOS\n",
+    "   - The spectral DOS (edge and bound atoms). What is special about this quantity on the bound atoms?\n",
+    "   - The bulk (electrode) DOS\n",
     "\n",
-    "**TIME**: Do the calculation for various `TBT.Contour.Eta` values, in different folders. Then compare the same DOS as above, what changes, why? Which DOS changes the most? Edge atoms or bound atoms?"
+    "**TIME**: Do the calculation for various `TBT.Contour.Eta` values, in different folders. Then compare the same DOS as above. What changes? Why? Which DOS changes the most? The DOS on edge atoms or on bound atoms?"
    ]
   },
   {
@@ -151,7 +151,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Density of states"
+    "### Density-of-states"
    ]
   },
   {
@@ -221,9 +221,9 @@
    "source": [
     "### Learned lessons\n",
     "\n",
-    "- Extraction of number of coupled elements via `.edges` for the Hamiltonian.\n",
+    "- Extraction of coupled elements via `.edges` for the Hamiltonian.\n",
     "- Manipulating the Hamiltonian *after* it has been created (*very* fast!)\n",
-    "- Extract data only for single $k$-points, the lesson learned is also applicable for a subset of all $k$-points.\n",
+    "- Extract data only for single $k$-points. The lesson learned is also applicable for a subset of $k$-points.\n",
     "- Extraction of various physical quantities from the `*.TBT.nc` file\n",
     "- How to visualize bound states"
    ]


### PR DESCRIPTION
Most tutorials contain many minor changes. A couple of them (*TB_07* and *08*, if I recall) contain more substantial changes, which we previously discussed (equation variables etc). Note that in *TB_08* you should modify some of the sentences, because I did not know what was the scientifically-correct naming of a couple of variables, so I left a couple of **to_be_filled** terms that, of course, should be replaced.

More generally, I think the *bond-currents* should be either included as a separate tutorial or simply removed completely. Otherwise, I find, it is quite confusing as the student will feel he/she is supposed to know that - when, in fact, it is a very advanced topic which is not included in the workshop. We already discussed this, but I think it might be worth including a dedicated tutorial for the next session of the course.