### PR TITLE
Minor changes to TS tutorials.

### DIFF
--- a/TS_01/run.ipynb
+++ b/TS_01/run.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "This example will *only* create the structures for input into TranSiesta. I.e. `sisl`'s capabilities of creating geometries with different species is a core functionality which is handy for creating geometries for Siesta/TranSiesta.\n",
     "\n",
-    "This example will teach you one of the *most important* aspect of performing a successful DFT+NEGF calculation. Namely, that the electrodes should *only* couple to its nearest neighbouring cell."
+    "This example will teach you one of the *most important* aspects of performing a successful DFT+NEGF calculation. Namely, that the electrodes should *only* couple to its nearest neighbouring cell."
    ]
   },
   {
@@ -94,7 +94,7 @@
     "\n",
     "   (*general advice: you don't need to do it for this exercise*)\n",
     "4. Run TranSiesta\n",
-    "  - Go through the output of TranSiesta to assert that it has run without error (always do this!) (always, **always** do THIS!)\n",
+    "  - Go through the output of TranSiesta to assert that it has run without errors (always do this!) (always, **always** do THIS!)\n",
     "  - Ensure the SCF has indeed converged, TranSiesta should not stop because of the maximum allowed iterations is too small. Optionally, you may use this flag `SCF.MustConverge T` (the default) to make TranSiesta die if it does not converge.\n",
     "  - Ensure that the `dQ` column is close to $0$, below $0.01$ is preferable. Further, it is advised that the last couple of iterations also obey this condition.\n",
     "  - Go through the lines after:\n",
@@ -139,8 +139,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Evidently TranSiesta does not allow too small electrodes as that will create an erroneous coupling to the semi-infinite directions. Luckily this may easily be inferred in the electrode output by looking for this keyword: `Internal auxiliary supercell`. The output of TranSiesta will print 3 numbers $\\langle A\\rangle \\mathrm{x} \\langle B\\rangle \\mathrm{x}\\langle C\\rangle$ which corresponds to the number of neighbouring unit-cells the primary unit-cell connects to. The important number to look for is the number corresponding to the semi-infinite direction.  \n",
-    "What should this number be in order to preserve nearest-neighbour unit-cell interactions? Say, if the semi-infinite is along the $\\langle A\\rangle$ direction, what should the number $\\langle A\\rangle$ (always!) be?"
+    "Evidently TranSiesta does not allow too small electrodes as that would create an erroneous coupling along the semi-infinite directions. Luckily, this may easily be inferred in the electrode output by looking for this keyword: `Internal auxiliary supercell`. The output of TranSiesta will print 3 numbers $\\langle A\\rangle \\mathrm{x} \\langle B\\rangle \\mathrm{x}\\langle C\\rangle$ which corresponds to the number of neighbouring unit-cells the primary unit-cell connects to. The important number to look for is the number corresponding to the semi-infinite direction.  \n",
+    "What should this number be in order to preserve nearest-neighbour unit-cell interactions **only**? Say, if the semi-infinite electrode sits along the $\\langle A\\rangle$ direction, what should the number $\\langle A\\rangle$ (always!) be?"
    ]
   }
  ],

--- a/TS_02/run.ipynb
+++ b/TS_02/run.ipynb
@@ -57,7 +57,7 @@
     "\n",
     "1. Do not start by performing any $V\\neq0$ calculations until you are perfectly sure that your $V=0$ calculation is well converged and well-behaved, i.e. a small `dQ` (see [TS 1](../TS_01/run.ipynb)).\n",
     "2. When performing bias calculations, you are recommended to create a new directory for each bias: `TS_<V>`.\n",
-    "3. *Any* bias calculation should be a restart by using the ***closest*** bias calculations TranSiesta density matrix. This can be ensured by copying the `siesta.TSDE` file from the ***closest*** bias calculation to the current simulation directory. I.e.\n",
+    "3. *Any* bias calculation should be a restart by using the ***closest*** bias calculation TranSiesta density matrix. This can be ensured by copying the `siesta.TSDE` file from the ***closest*** bias calculation to the current simulation directory. I.e.\n",
     "\n",
     "   - First run $V=0$ in `TS_0`, ensure convergence etc.\n",
     "   - Second run $V=0.5\\,\\mathrm{eV}$ in `TS_0.5`, copy `TS_0/siesta.TSDE` to `TS_0.5/` and start run.\n",
@@ -86,6 +86,7 @@
     "    # Check that it has converged...\n",
     "    ```\n",
     "  After every calculation, go through the output to ensure everything is well-behaved. Note that the output of a bias calculation is different from a non-bias calculation, they are more detailed.\n",
+    "\n",
     "5. An additional analysis (before going to the transport calculations) is to calculate the potential drop in the junction. In sisl this is easy:"
    ]
   },
@@ -163,7 +164,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**TIME**: A remark on this exercise. Think why applying a bias to a bulk system is wrong. If you can't immediately figure this out, try and create a longer system by replacing `device = elec.tile(3, axis=0)` with, say: `device = elec.tile(6, axis=0)` and redo the calculation for a given bias. Then compare the potential profiles. Furthermore, try and imagine a physical device with potential profile you create? Would it be possible?"
+    "**TIME**: A remark on this exercise. Think why applying a bias to a bulk system is wrong. If you can't immediately figure this out, try and create a longer system by replacing `device = elec.tile(3, axis=0)` with, say: `device = elec.tile(6, axis=0)` and redo the calculation for a given bias. Then compare the potential profiles. Furthermore, try and imagine a physical device with the potential profile you create? Would it be possible?"
    ]
   },
   {

--- a/TS_04/run.ipynb
+++ b/TS_04/run.ipynb
@@ -118,7 +118,7 @@
    "source": [
     "Performing NEGF calculations for $N$-electrodes with an applied bias is *extremely* difficult, and one should first take on this task once the traditional TranSiesta 2-electrode setup is a breeze.\n",
     "\n",
-    "One of the main difficulties in performing *good* $N$-electrode calculations is the Poisson solution and the boundary conditions. These are more difficult to impose when having more than 2 electrodes or 1 electrode (only 2 electrode setups are *easy*).\n",
+    "One of the main difficulties in performing *good* $N$-electrode calculations is the Poisson solution and the boundary conditions. These are more difficult to impose when having more than 2 electrodes or when having only 1 electrode (only 2 electrode setups are *easy*).\n",
     "\n",
     "- In a 2 terminal device it is obvious how the applied bias is located (a ramp between the two electrodes), however,\n",
     "  when dealing with more than 2 electrodes all electrodes may have a different chemical potential and thus the variations in how to apply the bias becomes infinite.  \n",

--- a/TS_05/run.ipynb
+++ b/TS_05/run.ipynb
@@ -20,11 +20,11 @@
     "\n",
     "Here a pristine graphene flake will be constructed, and subsequently a Carbon chain will act as an STM-like tip to simulate STM experiments.\n",
     "\n",
-    "As the Carbon chain is terminated to vacuum, the dangling bonds will create spurious effects very different from a pristine, bulk chain. To understand why it is necessary to add buffer atoms, it is useful to understand the TranSiesta method. **Any** TranSiesta calculation starts with calculating an initial guess for the Hamiltonian as input for the Green function method:\n",
+    "As the Carbon chain is terminated to vacuum, the dangling bonds will create spurious effects very different from a pristine, bulk chain. To understand why it is necessary to add buffer atoms, it is useful to understand the TranSiesta method. **Any** TranSiesta calculation starts with calculating an initial guess for the Hamiltonian ($\\mathbf H$) as input for the Green function method:\n",
     "\\begin{equation}\n",
     "   \\mathbf G^{-1}(E) = \\mathbf S (E+i\\eta) - \\mathbf H - \\sum_i\\boldsymbol\\Sigma_i\n",
     "\\end{equation}\n",
-    "If the initial $\\mathbf H'$ represents a Hamiltonian close to the open-boundary problem $\\mathbf H$; it will converge with a higher probability, and in much less time. Improving the initial guess Hamiltonian is time well-worth spent as TranSiesta is, typically, more difficult to converge.\n",
+    "Where $\\mathbf G^{-1}(E)$ is the device Green function, $\\mathbf S$ the overlap matrix and $\\Sigma_i$ the self-energy for the *ith*-electrode. If the initial $\\mathbf H'$ represents a Hamiltonian close to the open-boundary problem $\\mathbf H$; the TranSiesta calculation will converge with a higher probability, and in much less time. Improving the initial guess Hamiltonian is time well-worth spent as TranSiesta is, typically, more difficult to converge.\n",
     "\n",
     "As an example, consider the Hamiltonian for the chain:\n",
     "\n",
@@ -94,9 +94,9 @@
     "- Create a new directory for a different range of buffer atoms, from 0 to 4, start by using 4 buffer atoms.  \n",
     "  How does convergence behave for different number of buffer atoms?\n",
     "  \n",
-    "  **REMARK** there are 2 places in the fdf file you should change when changing the number of atoms (the electrode atom specification *and* the buffer atoms).\n",
+    "  **REMARK**: There are 2 places in the fdf file you should change when changing the number of buffer atoms (the electrode atom specification *and* the buffer atoms).\n",
     "- Calculate transport properties for all (converged) TranSiesta calculations\n",
-    "- Plot the transmission and DOS for all TBtrans calculations, do they differ?"
+    "- Plot the transmission and DOS for all TBtrans calculations. Do they differ?"
    ]
   },
   {

--- a/TS_05/run.ipynb
+++ b/TS_05/run.ipynb
@@ -9,6 +9,7 @@
     "import sisl\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "\n",
     "%matplotlib inline"
    ]
   },
@@ -24,7 +25,7 @@
     "\\begin{equation}\n",
     "   \\mathbf G^{-1}(E) = \\mathbf S (E+i\\eta) - \\mathbf H - \\sum_i\\boldsymbol\\Sigma_i\n",
     "\\end{equation}\n",
-    "Where $\\mathbf G^{-1}(E)$ is the device Green function, $\\mathbf S$ the overlap matrix and $\\Sigma_i$ the self-energy for the *ith*-electrode. If the initial $\\mathbf H'$ represents a Hamiltonian close to the open-boundary problem $\\mathbf H$; the TranSiesta calculation will converge with a higher probability, and in much less time. Improving the initial guess Hamiltonian is time well-worth spent as TranSiesta is, typically, more difficult to converge.\n",
+    "Where $\\mathbf G(E)$ is the device Green function, $\\mathbf S$ the overlap matrix and $\\Sigma_i$ the self-energy for the *ith*-electrode. If the initial $\\mathbf H'$ represents a Hamiltonian close to the open-boundary problem $\\mathbf H$; the TranSiesta calculation will converge with a higher probability, and in much less time. Improving the initial guess Hamiltonian is time well-worth spent as TranSiesta is, typically, more difficult to converge.\n",
     "\n",
     "As an example, consider the Hamiltonian for the chain:\n",
     "\n",
@@ -47,8 +48,8 @@
    "source": [
     "graphene = sisl.geom.graphene(1.44)\n",
     "elec = graphene.tile(2, axis=0)\n",
-    "elec.write('ELEC_GRAPHENE.fdf')\n",
-    "elec.write('ELEC_GRAPHENE.xyz')"
+    "elec.write(\"ELEC_GRAPHENE.fdf\")\n",
+    "elec.write(\"ELEC_GRAPHENE.xyz\")"
    ]
   },
   {
@@ -57,10 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C1d = sisl.Geometry([[0,0,0]], graphene.atoms[0], [10, 10, 1.4])\n",
+    "C1d = sisl.Geometry([[0, 0, 0]], graphene.atoms[0], [10, 10, 1.4])\n",
     "elec_chain = C1d.tile(4, axis=2)\n",
-    "elec_chain.write('ELEC_CHAIN.fdf')\n",
-    "elec_chain.write('ELEC_CHAIN.xyz')\n",
+    "elec_chain.write(\"ELEC_CHAIN.fdf\")\n",
+    "elec_chain.write(\"ELEC_CHAIN.xyz\")\n",
     "chain = elec_chain.tile(4, axis=2)"
    ]
   },
@@ -74,14 +75,14 @@
     "\n",
     "# Attach the chain on-top of an atom\n",
     "# First find an atom in the middle of the device\n",
-    "idx = device.close(device.center(what='xyz'), R=1.45)[1]\n",
+    "idx = device.close(device.center(what=\"xyz\"), R=1.45)[1]\n",
     "# Attach the chain at a distance of 2.25 along the third lattice vector\n",
     "device = device.attach(idx, chain, 0, dist=2.25, axis=2)\n",
     "# Add vacuum along chain, we really no not care how much vacuum, but it\n",
     "# is costly on memory, not so much on performance.\n",
     "device = device.add_vacuum(15, axis=2)\n",
-    "device.write('DEVICE.fdf')\n",
-    "device.write('DEVICE.xyz')"
+    "device.write(\"DEVICE.fdf\")\n",
+    "device.write(\"DEVICE.xyz\")"
    ]
   },
   {
@@ -105,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tbt = sisl.get_sile('siesta.TBT.nc')"
+    "tbt = sisl.get_sile(\"siesta.TBT.nc\")"
    ]
   },
   {
@@ -118,7 +119,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -132,7 +133,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Very minor changes here and there. Nothing substantial.

I think that in `TS_04` there should be some sort of explanation about how the boundary conditions of the external Poisson solution (by using the sisl `solve_poisson` method) are "better" than the one internally set by TranSiesta. I mean, in the tutorial it is simply stated that it is better, but having one line explaining ***why*** it is better would be nice. Otherwise there is a bunch of relatively complex new code, but the student does not really know what is actually being changed. Just a suggestion for future workshops.

Also, in `TS_05`, upon building the device should this line:
```python
idx = device.close(device.center(what='xyz'), R=1.45)[1]
```
be replaced by this:
```python
idx = device.close(device.center(what='xyz'), R=1.45)[0]
```
Maybe I'm missing something, but I think we should take the closest atom to the graphene center.. no?? Just a minor detail anyways.